### PR TITLE
[FEATURE] : Backup 도메인 컨트롤러, 서비스, 레포지토리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,22 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+}
+
+def querydslDir = "build/generated/querydsl"
+
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean {
+	delete file(querydslDir)
 }
 
 tasks.named('test') {

--- a/src/main/java/team7/hrbank/common/config/QuerydslConfig.java
+++ b/src/main/java/team7/hrbank/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package team7.hrbank.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/team7/hrbank/common/dto/PageResponse.java
+++ b/src/main/java/team7/hrbank/common/dto/PageResponse.java
@@ -1,0 +1,14 @@
+package team7.hrbank.common.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+   List<T> content,
+   Object nextCursor,
+   Long nextIdAfter,
+   int size,
+   int totalElements,
+   boolean hasNext
+
+) {
+}

--- a/src/main/java/team7/hrbank/domain/backup/controller/BackupController.java
+++ b/src/main/java/team7/hrbank/domain/backup/controller/BackupController.java
@@ -1,0 +1,72 @@
+package team7.hrbank.domain.backup.controller;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team7.hrbank.common.dto.PageResponse;
+import team7.hrbank.domain.backup.dto.BackupDto;
+import team7.hrbank.domain.backup.entity.BackupStatus;
+import team7.hrbank.domain.backup.service.BackupService;
+import team7.hrbank.domain.backup.service.BackupServiceImpl;
+
+@RestController
+@RequestMapping("/api/backups")
+@RequiredArgsConstructor
+public class BackupController {
+
+  private final BackupService backupService;
+
+  // 200, 400, 500
+  @GetMapping
+  public ResponseEntity<PageResponse<BackupDto>> getBackupList(
+      @RequestParam(name = "worker", required = false) String worker,
+      @RequestParam(name = "status", required = false) BackupStatus status,
+      @RequestParam(name = "startedAtFrom", required = false) Instant startedAtFrom,
+      @RequestParam(name = "startedAtTo", required = false) Instant startedAtTo,
+      @RequestParam(name = "idAfter", required = false) Long idAfter,
+      @RequestParam(name = "cursor", required = false) Instant cursor,
+      @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+      @RequestParam(name = "sortField", required = false, defaultValue = "startedAt") String sortField,
+      @RequestParam(name = "sortDirection", required = false, defaultValue = "DESC") String sortDirection
+      ){
+
+    PageResponse<BackupDto> response = backupService.findBackupsOfCondition(
+        worker,
+        status,
+        startedAtFrom,
+        startedAtTo,
+        idAfter,
+        cursor,
+        size,
+        sortField,
+        sortDirection
+    );
+
+    return ResponseEntity.ok(response);
+  }
+
+  // 200, 400, 409, 500
+  @PostMapping
+  public ResponseEntity<BackupDto> generateBackup(){
+    BackupDto response = backupService.startBackup();
+    return ResponseEntity.ok(response);
+  }
+
+  // 200, 400, 500
+  @GetMapping("/latest")
+  public ResponseEntity<BackupDto> getLatestBackup(@RequestParam(defaultValue = "COMPLETED", required = false, name = "status") BackupStatus status){
+    BackupDto response = backupService.findLatestBackupByStatus(status);
+    return ResponseEntity.ok(response);
+  }
+
+}

--- a/src/main/java/team7/hrbank/domain/backup/entity/Backup.java
+++ b/src/main/java/team7/hrbank/domain/backup/entity/Backup.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.AccessLevel;

--- a/src/main/java/team7/hrbank/domain/backup/entity/BackupStatus.java
+++ b/src/main/java/team7/hrbank/domain/backup/entity/BackupStatus.java
@@ -1,5 +1,5 @@
 package team7.hrbank.domain.backup.entity;
 
 public enum BackupStatus {
-  진행중, 완료, 실패, 건너뜀
+  IN_PROGRESS, COMPLETED, FAILED, SKIPPED
 }

--- a/src/main/java/team7/hrbank/domain/backup/exception/BackupException.java
+++ b/src/main/java/team7/hrbank/domain/backup/exception/BackupException.java
@@ -1,0 +1,8 @@
+package team7.hrbank.domain.backup.exception;
+
+public class BackupException extends RuntimeException {
+
+  public BackupException() {
+    super();
+  }
+}

--- a/src/main/java/team7/hrbank/domain/backup/mapper/BackupMapper.java
+++ b/src/main/java/team7/hrbank/domain/backup/mapper/BackupMapper.java
@@ -1,0 +1,13 @@
+package team7.hrbank.domain.backup.mapper;
+
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+import team7.hrbank.domain.backup.dto.BackupDto;
+import team7.hrbank.domain.backup.entity.Backup;
+
+@Component // TODO : 병합 후 Mapper 로 수정
+public interface BackupMapper {
+  BackupDto fromEntity(Backup backup);
+  List<BackupDto> fromEntityList(List<Backup> backups);
+}

--- a/src/main/java/team7/hrbank/domain/backup/repository/BackupRepository.java
+++ b/src/main/java/team7/hrbank/domain/backup/repository/BackupRepository.java
@@ -1,0 +1,10 @@
+package team7.hrbank.domain.backup.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import team7.hrbank.domain.backup.entity.Backup;
+import team7.hrbank.domain.backup.entity.BackupStatus;
+
+public interface BackupRepository extends JpaRepository<Backup, Long>, CustomBackupRepository {
+  Optional<Backup> findFirstByStatusOrderByStartedAtDesc(BackupStatus status);
+}

--- a/src/main/java/team7/hrbank/domain/backup/repository/CustomBackupRepository.java
+++ b/src/main/java/team7/hrbank/domain/backup/repository/CustomBackupRepository.java
@@ -1,0 +1,21 @@
+package team7.hrbank.domain.backup.repository;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import team7.hrbank.domain.backup.entity.Backup;
+import team7.hrbank.domain.backup.entity.BackupStatus;
+
+public interface CustomBackupRepository {
+  List<Backup> findBackups(
+      String worker,
+      BackupStatus status,
+      Instant startedAtFrom,
+      Instant startedAtTo,
+      Long idAfter,
+      Instant cursor,
+      int size,
+      String sortField,
+      String sortDirection
+  );
+}

--- a/src/main/java/team7/hrbank/domain/backup/repository/CustomBackupRepositoryImpl.java
+++ b/src/main/java/team7/hrbank/domain/backup/repository/CustomBackupRepositoryImpl.java
@@ -1,0 +1,96 @@
+package team7.hrbank.domain.backup.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import team7.hrbank.domain.backup.entity.Backup;
+import team7.hrbank.domain.backup.entity.BackupStatus;
+import team7.hrbank.domain.backup.entity.QBackup;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomBackupRepositoryImpl implements CustomBackupRepository {
+
+  private final JPAQueryFactory queryFactory;
+  private final QBackup backup = QBackup.backup;
+
+  @Override
+  public List<Backup> findBackups(
+      String worker,
+      BackupStatus status,
+      Instant startedAtFrom,
+      Instant startedAtTo,
+      Long idAfter,
+      Instant cursor,
+      int size,
+      String sortField,
+      String sortDirection
+  ) {
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    if (worker != null) {
+      where.and(backup.worker.containsIgnoreCase(worker));
+    }
+
+    if (status != null) {
+      where.and(backup.status.eq(status));
+    }
+
+    if (startedAtFrom != null) {
+      where.and(backup.startedAt.goe(startedAtFrom));
+    }
+
+    if (startedAtTo != null) {
+      where.and(backup.startedAt.loe(startedAtTo));
+    }
+
+    if (idAfter != null) {
+      where.and(backup.id.goe(idAfter)); // 테스트 후 gt 로 변경해야 할 수도
+    }
+
+    if (cursor != null) {
+      where.and(
+          "DESC".equalsIgnoreCase(sortDirection)
+              ? backup.startedAt.lt(cursor)
+              : backup.startedAt.gt(cursor)
+      );
+    }
+
+    OrderSpecifier<?> specifier = getOrderSpecifier(sortField, sortDirection);
+
+    return queryFactory
+        .selectFrom(backup)
+        .where(where)
+        .orderBy(specifier)
+        .limit(size)
+        .fetch();
+  }
+
+  private OrderSpecifier<?> getOrderSpecifier(String field, String direction) {
+    switch (field) {
+      case "startedAt":
+        if ("DESC".equalsIgnoreCase(direction)) {
+          return backup.startedAt.desc();
+        } else {
+          return backup.startedAt.asc();
+        }
+      case "endedAt":
+        if ("DESC".equalsIgnoreCase(direction)) {
+          return backup.endedAt.desc();
+        } else {
+          return backup.endedAt.asc();
+        }
+      case "status":
+        return backup.status.asc();
+      default:
+        return backup.startedAt.desc();
+    }
+  }
+}

--- a/src/main/java/team7/hrbank/domain/backup/service/BackupService.java
+++ b/src/main/java/team7/hrbank/domain/backup/service/BackupService.java
@@ -1,0 +1,27 @@
+package team7.hrbank.domain.backup.service;
+
+import java.time.Instant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import team7.hrbank.common.dto.PageResponse;
+import team7.hrbank.domain.backup.dto.BackupDto;
+import team7.hrbank.domain.backup.entity.BackupStatus;
+
+public interface BackupService {
+
+  PageResponse<BackupDto> findBackupsOfCondition(
+      String worker,
+      BackupStatus status,
+      Instant startedAtFrom,
+      Instant startedAtTo,
+      Long idAfter,
+      Instant cursor,
+      int size,
+      String sortField,
+      String sortDirection
+  );
+
+  BackupDto startBackup();
+
+  BackupDto findLatestBackupByStatus(BackupStatus status);
+}

--- a/src/main/java/team7/hrbank/domain/backup/service/BackupServiceImpl.java
+++ b/src/main/java/team7/hrbank/domain/backup/service/BackupServiceImpl.java
@@ -1,0 +1,110 @@
+package team7.hrbank.domain.backup.service;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import team7.hrbank.common.dto.PageResponse;
+import team7.hrbank.domain.backup.dto.BackupDto;
+import team7.hrbank.domain.backup.entity.Backup;
+import team7.hrbank.domain.backup.entity.BackupStatus;
+import team7.hrbank.domain.backup.exception.BackupException;
+import team7.hrbank.domain.backup.mapper.BackupMapper;
+import team7.hrbank.domain.backup.repository.BackupRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BackupServiceImpl implements BackupService{
+
+  private final BackupRepository backupRepository;
+  private final BackupMapper backupMapper;
+
+  // TODO : 최적화 필요
+  @Override
+  public PageResponse<BackupDto> findBackupsOfCondition(
+      String worker,
+      BackupStatus status,
+      Instant startedAtFrom,
+      Instant startedAtTo,
+      Long idAfter,
+      Instant cursor,
+      int size,
+      String sortField,
+      String sortDirection
+  ) {
+
+    List<Backup> backups = backupRepository.findBackups(
+        worker,
+        status,
+        startedAtFrom,
+        startedAtTo,
+        idAfter,
+        cursor,
+        size,
+        sortField,
+        sortDirection
+    );
+
+    if(backups.isEmpty()) {
+      return new PageResponse<>(
+          Collections.emptyList(),
+          null,
+          null,
+          size,
+          0,
+          false
+      );
+    }
+
+    List<Backup> nextPageCheck = backupRepository.findBackups(
+        worker,
+        status,
+        startedAtFrom,
+        startedAtTo,
+        backups.get(backups.size() - 1).getId(),  // 마지막 요소의 ID를 커서로 사용
+        null,  // 새로운 커서 기준 (추가 데이터 확인용)
+        1,  // 다음 데이터가 있는지만 확인하기 위해 1개만 조회
+        sortField,
+        sortDirection
+    );
+
+    boolean hasNext = !nextPageCheck.isEmpty();
+    Long nextIdAfter = backups.get(backups.size() - 1).getId();
+    Instant nextCursor = backups.stream()
+        .map(Backup::getStartedAt)
+        .sorted(
+            "DESC".equalsIgnoreCase(sortDirection)
+            ? Comparator.reverseOrder() : Comparator.naturalOrder()
+        ).findFirst()
+        .orElse(null);
+
+    return new PageResponse<>(
+        backupMapper.fromEntityList(backups),
+        nextCursor,
+        nextIdAfter,
+        size,
+        0,
+        hasNext
+    );
+  }
+
+  @Override
+  public BackupDto startBackup() {
+    return null;
+  }
+
+  @Override
+  public BackupDto findLatestBackupByStatus(BackupStatus status) {
+    // 에러 처리 방식 논의
+    Backup backup = backupRepository.findFirstByStatusOrderByStartedAtDesc(status)
+        .orElseThrow(() -> new BackupException());
+
+    return backupMapper.fromEntity(backup);
+  }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -36,19 +36,20 @@ CREATE TABLE employees (
 
 CREATE TABLE employee_history (
     id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    employee_number VARCHAR(50) NOT NULL,
+    employee_number VARCHAR(50) NULL, -- 논의 필요, employee 삭제시 동작
     type VARCHAR(20) NOT NULL CHECK (type IN ('직원 추가', '정보 수정', '직원 삭제')),
     details JSONB NULL,
     memo TEXT NULL,
     ip_address INET NOT NULL,
     created_at TIMESTAMPTZ NOT NULL,
-    CONSTRAINT fk_employee_history_employee FOREIGN KEY (employee_number) REFERENCES employees (employee_number) ON SET NULL
+    CONSTRAINT fk_employee_history_employee FOREIGN KEY (employee_number) REFERENCES employees (employee_number) ON delete SET NULL
 );
 
 
 CREATE TABLE backup_history (
     id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     worker INET NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
     start_time TIMESTAMPTZ NOT NULL,
     end_time TIMESTAMPTZ NULL,
     status VARCHAR(50) NOT NULL CHECK (status IN ('진행중', '완료', '실패', '건너뜀')),


### PR DESCRIPTION
## 🛰️ Issue Number

[이슈 14](https://github.com/Kiki1875b/Part1-HRBank-Team7/issues/14)

## 🪐 작업 내용
- QueryDsl 의존성 추가
- QueryDsl configuration 추가
- PageResponse 정의
- Backup 도메인에 대한
   - Service
   - Repository
   - Controller 
- Backup 목록 조회시 QueryDsl 사용
- SQL 수정 -> employee_history 는 기존에 employee 삭제시 cascade delete. 수정후, cascade set null 로 변경

## 📚 Reference

https://velog.io/@funnysunny08/QueryDSL-%EC%97%AC%EB%9F%AC-%EA%B8%B0%EC%A4%80-%EB%B3%84%EB%A1%9C-%EC%A0%95%EB%A0%AC%ED%95%98%EA%B8%B0

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요? - 의존성 및 추가 설계가 필요하여 빌드만 확인
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
