### PR TITLE
[FIX] 부서명 검증 / 부서 목록 조회시 내림차순에서 중복조회되는 문제 해결

### DIFF
--- a/src/main/java/team7/hrbank/domain/department/repository/CustomDepartmentRepositoryImpl.java
+++ b/src/main/java/team7/hrbank/domain/department/repository/CustomDepartmentRepositoryImpl.java
@@ -78,8 +78,8 @@ public class CustomDepartmentRepositoryImpl implements CustomDepartmentRepositor
 
     // 페이지의 마지막 항목을 가져와서 nextIdAfter와 nextCursor를 설정
     if (hasNext) {
-      nextIdAfter = getNextIdAfter(departments);
-      nextCursor = getNextCursor(departments, sortField);
+      nextIdAfter = getNextIdAfter(departments, sortDirection);
+      nextCursor = getNextCursor(departments, sortField, sortDirection);
     }
 
 
@@ -170,21 +170,21 @@ public class CustomDepartmentRepositoryImpl implements CustomDepartmentRepositor
   }
 
   //페이지 마지막요소 Id 반환
-  private Long getNextIdAfter(List<Department> departments) {
+  private Long getNextIdAfter(List<Department> departments, String sortDirection) {
     if (departments.isEmpty()) {
       return 0L;
     } else {
-      Department lastDepartment = departments.get(departments.size() - 1);
+      Department lastDepartment = sortDirection.equals("desc")?departments.get(1):departments.get(departments.size() - 1);
       return lastDepartment.getId();
     }
   }
 
   //페이지 마지막요소 정렬기준 필드값 64바이트로 반환
-  private String getNextCursor(List<Department> departments, String sortField) {
+  private String getNextCursor(List<Department> departments, String sortField, String sortDirection) {
     if (departments.isEmpty()) {
       return null;
     } else {
-      Department lastDepartment = departments.get(departments.size() - 1);
+      Department lastDepartment = sortDirection.equals("desc")?departments.get(1):departments.get(departments.size() - 1);
       return encodeCursor(lastDepartment, sortField);
     }
   }

--- a/src/main/java/team7/hrbank/domain/department/service/DepartmentServiceImpl.java
+++ b/src/main/java/team7/hrbank/domain/department/service/DepartmentServiceImpl.java
@@ -4,8 +4,6 @@ import jakarta.transaction.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import team7.hrbank.common.exception.GlobalExceptionHandler;
 import team7.hrbank.domain.department.dto.*;
 import team7.hrbank.domain.department.entity.Department;
 import team7.hrbank.domain.department.repository.CustomDepartmentRepository;
@@ -87,13 +85,20 @@ public class DepartmentServiceImpl implements DepartmentService {
 
 
   private void validateName(String name) {
+    if (name.contains(" ")){
+      throw new InvalidParameterException("부서 이름에 공백은 포함될 수 없습니다.");
+    }
     if (!departmentRepository.findByName(name).isEmpty()) {
       throw new InvalidParameterException("이미 존재하는 부서 이름입니다.");
     };
+
   }
 
   private void validateName(Long id, String name) {
     Optional<Department> existingDepartment = departmentRepository.findByName(name);
+    if (name.contains(" ")){
+      throw new InvalidParameterException("부서 이름에 공백은 포함될 수 없습니다.");
+    }
     if (!existingDepartment.isEmpty()&&!(existingDepartment.get().getId().equals(id))) {
       throw new InvalidParameterException("이미 존재하는 부서 이름입니다.");
     }


### PR DESCRIPTION
## 🛰️ Issue Number

내용 간단 요약 *
## 🪐 작업 내용

[부서명 검증]
원래는 부서명에 공백이 포함될 수 있었으나 공백은 불필요하다고 판단하였음.
'부서명 '과 '부서명'이 모두 등록되면서 혼란이 발생할 여지가 존재하기 때문. 또한 실제로 부서명에 공백을 포함하여 작명하는 부서는 드묾.
따라서 부서명 검증시 동일부서명으로 존재하는 기존 부서가 있는지 확인함에 더해, 요청 파라미터로 들어온 값에 공백이 포함되어있는지를 검증 후 해당 조건 위반시 예외를 발생시키도록 수정하였음. 

[부서 중복조회 해결]
부서 목록을 내림차순으로 조회시 중복 발생하였으나 이는 내림차순/오름차순 각각 마지막 요소가 다름을 고려하지 않았었던 것이 원인.
따라서 마지막요소 인덱스를 각 정렬방향에 맞게 수정하여 해결함.  

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
